### PR TITLE
Foreground notification service 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
     defaultConfig {
         applicationId "kiwi.root.an2linuxclient"
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 9
         versionName "0.7.0"
     }
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.madgag.spongycastle:pkix:1.54.0.0' // for X.509 certificate generation
+    api 'com.android.support:appcompat-v7:27.1.1'
+    api 'com.android.support:design:27.1.1'
+    api 'com.madgag.spongycastle:pkix:1.54.0.0' // for X.509 certificate generation
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Needed since 8.1 to obtain the SSID -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
@@ -69,6 +70,12 @@
         <service
             android:name=".utils.AN2LinuxService"
             android:label="@string/utils_an2linux_service"/>
+
+        <receiver android:name="kiwi.root.an2linuxclient.utils.BootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,10 @@
             android:label="@string/activity_label_client_certificate"
             android:parentActivityName=".activities.MainSettingsActivity" />
 
+        <service
+            android:name=".utils.AN2LinuxService"
+            android:label="@string/utils_an2linux_service"/>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <!-- Needed since 8.1 to obtain the SSID -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/kiwi/root/an2linuxclient/activities/MainSettingsActivity.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/activities/MainSettingsActivity.java
@@ -56,10 +56,16 @@ public class MainSettingsActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        boolean useForegroundService = PreferenceManager.getDefaultSharedPreferences(this)
-                .getBoolean(getString(R.string.preference_enable_service), false);
-        if (useForegroundService){
-            startService(new Intent(this, AN2LinuxService.class));
+        boolean an2linuxEnabled = PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean(getString(R.string.preference_enable_an2linux), false);
+
+        if (an2linuxEnabled){
+            boolean useForegroundService = PreferenceManager.getDefaultSharedPreferences(this)
+                    .getBoolean(getString(R.string.preference_enable_service), false);
+
+            if (useForegroundService){
+                startService(new Intent(this, AN2LinuxService.class));
+            }
         }
     }
 
@@ -109,7 +115,10 @@ public class MainSettingsActivity extends AppCompatActivity {
     }
 
     private void changeForegroundService(boolean useForegroundService) {
-        if (useForegroundService){
+        boolean an2linuxEnabled = PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean(getString(R.string.preference_enable_an2linux), false);
+
+        if (an2linuxEnabled && useForegroundService){
             startService(new Intent(this, AN2LinuxService.class));
             displayNotificationHidingHelp();
         } else{
@@ -148,9 +157,17 @@ public class MainSettingsActivity extends AppCompatActivity {
                         if (!isNotificationAccessEnabled){
                             new AskNotificationAccessDialogFragment().show(getFragmentManager(), "AskNotificationAccessDialogFragment");
                         }
-                        if (!hasCoarseLocationPermission) {
+                        if (!hasCoarseLocationPermission){
                             new AskCoarseLocationAccessDialogFragment().show(getFragmentManager(), "AskCoarseLocationAccessDialogFragment");
                         }
+
+                        boolean useForegroundService = preference.getSharedPreferences().getBoolean(getString(R.string.preference_enable_service), false);
+
+                        if (useForegroundService){
+                            getActivity().startService(new Intent(getActivity(), AN2LinuxService.class));
+                        }
+                    } else{
+                        getActivity().stopService(new Intent(getActivity(), AN2LinuxService.class));
                     }
                     return true;
                 }

--- a/app/src/main/java/kiwi/root/an2linuxclient/activities/MainSettingsActivity.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/activities/MainSettingsActivity.java
@@ -51,12 +51,13 @@ public class MainSettingsActivity extends AppCompatActivity {
     private final static int HIDING_NOTIFICATION_ID = 2;
     private final static String INFORMATION_CHANNEL_ID = "AN2LinuxInformationChannel";
 
-    private boolean useForegroundService = false;
 
     @Override
     protected void onResume() {
         super.onResume();
 
+        boolean useForegroundService = PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean(getString(R.string.preference_enable_service), false);
         if (useForegroundService){
             startService(new Intent(this, AN2LinuxService.class));
         }
@@ -69,10 +70,6 @@ public class MainSettingsActivity extends AppCompatActivity {
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new SettingsFragment())
                 .commit();
-
-        if (useForegroundService){
-            startService(new Intent(this, AN2LinuxService.class));
-        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -111,8 +108,7 @@ public class MainSettingsActivity extends AppCompatActivity {
         }
     }
 
-    private void setUseForegroundService(boolean useForegroundService) {
-        this.useForegroundService = useForegroundService;
+    private void changeForegroundService(boolean useForegroundService) {
         if (useForegroundService){
             startService(new Intent(this, AN2LinuxService.class));
             displayNotificationHidingHelp();
@@ -165,7 +161,7 @@ public class MainSettingsActivity extends AppCompatActivity {
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     Activity activity = getActivity();
                     if (activity instanceof MainSettingsActivity){
-                        ((MainSettingsActivity) activity).setUseForegroundService((boolean) newValue);
+                        ((MainSettingsActivity) activity).changeForegroundService((boolean) newValue);
                     }
                     return true;
                 }

--- a/app/src/main/java/kiwi/root/an2linuxclient/activities/MainSettingsActivity.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/activities/MainSettingsActivity.java
@@ -42,9 +42,17 @@ import kiwi.root.an2linuxclient.crypto.KeyGeneratorService;
 import kiwi.root.an2linuxclient.data.MobileServer;
 import kiwi.root.an2linuxclient.data.ServerDatabaseHandler;
 import kiwi.root.an2linuxclient.data.WifiServer;
+import kiwi.root.an2linuxclient.utils.AN2LinuxService;
 import kiwi.root.an2linuxclient.utils.ConnectionHelper;
 
 public class MainSettingsActivity extends AppCompatActivity {
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        startService(new Intent(this, AN2LinuxService.class));
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,6 +61,8 @@ public class MainSettingsActivity extends AppCompatActivity {
         getFragmentManager().beginTransaction()
                 .replace(android.R.id.content, new SettingsFragment())
                 .commit();
+
+        startService(new Intent(this, AN2LinuxService.class));
     }
 
     public static class SettingsFragment extends PreferenceFragment {

--- a/app/src/main/java/kiwi/root/an2linuxclient/utils/AN2LinuxService.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/utils/AN2LinuxService.java
@@ -12,11 +12,8 @@ import kiwi.root.an2linuxclient.R;
 import kiwi.root.an2linuxclient.activities.MainSettingsActivity;
 
 public class AN2LinuxService extends Service {
-
-    @Override
-    public void onCreate() {
-        super.onCreate();
-    }
+    private final static int SERVICE_NOTIFICATION_ID = 1;
+    private final static String SERVICE_CHANNEL_ID = "AN2LinuxServiceChannel";
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -40,16 +37,14 @@ public class AN2LinuxService extends Service {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private String createNotificationChannel() {
-        String channelId = "AN2LinuxChannel";
-        String channelName = "AN2Linux foreground notification channel";
-        NotificationChannel chan = new NotificationChannel(channelId,
-                channelName, NotificationManager.IMPORTANCE_MIN);
+        NotificationChannel chan = new NotificationChannel(SERVICE_CHANNEL_ID,
+                getString(R.string.main_enable_service_notification_channel_name), NotificationManager.IMPORTANCE_MIN);
         chan.setLightColor(Color.GREEN);
         chan.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
-        NotificationManager service = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        assert service != null;
-        service.createNotificationChannel(chan);
-        return channelId;
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        assert notificationManager != null;
+        notificationManager.createNotificationChannel(chan);
+        return SERVICE_CHANNEL_ID;
     }
 
     private void do_foreground() {
@@ -65,14 +60,17 @@ public class AN2LinuxService extends Service {
         } else{
             notificationBuilder.setPriority(Notification.PRIORITY_MIN);
         }
-        notificationBuilder.setOngoing(true).setSmallIcon(R.mipmap.ic_launcher).setTicker("AN2Linux").setContentIntent(
+        notificationBuilder.setOngoing(true);
+        notificationBuilder.setSmallIcon(R.mipmap.ic_launcher);
+        notificationBuilder.setTicker(getString(R.string.main_enable_service_notification_channel_name));
+        notificationBuilder.setContentIntent(
                 PendingIntent.getActivity(this, 0,
                         new Intent(this, MainSettingsActivity.class),
                         PendingIntent.FLAG_UPDATE_CURRENT)
         );
         Notification n = notificationBuilder.build();
 
-        startForeground(1, n);
+        startForeground(SERVICE_NOTIFICATION_ID, n);
     }
 }
 

--- a/app/src/main/java/kiwi/root/an2linuxclient/utils/AN2LinuxService.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/utils/AN2LinuxService.java
@@ -1,0 +1,78 @@
+package kiwi.root.an2linuxclient.utils;
+
+import android.app.*;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Color;
+import android.os.Build;
+import android.os.IBinder;
+import android.support.annotation.RequiresApi;
+import android.support.v4.app.NotificationCompat;
+import kiwi.root.an2linuxclient.R;
+import kiwi.root.an2linuxclient.activities.MainSettingsActivity;
+
+public class AN2LinuxService extends Service {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        do_foreground();
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        stopSelf();
+        stopForeground(true);
+
+        super.onDestroy();
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private String createNotificationChannel() {
+        String channelId = "AN2LinuxChannel";
+        String channelName = "AN2Linux foreground notification channel";
+        NotificationChannel chan = new NotificationChannel(channelId,
+                channelName, NotificationManager.IMPORTANCE_MIN);
+        chan.setLightColor(Color.GREEN);
+        chan.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+        NotificationManager service = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        assert service != null;
+        service.createNotificationChannel(chan);
+        return channelId;
+    }
+
+    private void do_foreground() {
+        String channelID = "";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            channelID = createNotificationChannel();
+        }
+
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, channelID);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
+            notificationBuilder.setCategory(Notification.CATEGORY_SERVICE);
+        } else{
+            notificationBuilder.setPriority(Notification.PRIORITY_MIN);
+        }
+        notificationBuilder.setOngoing(true).setSmallIcon(R.mipmap.ic_launcher).setTicker("AN2Linux").setContentIntent(
+                PendingIntent.getActivity(this, 0,
+                        new Intent(this, MainSettingsActivity.class),
+                        PendingIntent.FLAG_UPDATE_CURRENT)
+        );
+        Notification n = notificationBuilder.build();
+
+        startForeground(1, n);
+    }
+}
+

--- a/app/src/main/java/kiwi/root/an2linuxclient/utils/BootReceiver.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/utils/BootReceiver.java
@@ -1,0 +1,24 @@
+package kiwi.root.an2linuxclient.utils;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.preference.PreferenceManager;
+import kiwi.root.an2linuxclient.R;
+
+public class BootReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        boolean an2linuxEnabled = PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.preference_enable_an2linux), false);
+
+        if (an2linuxEnabled){
+            boolean useForegroundService = PreferenceManager.getDefaultSharedPreferences(context)
+                    .getBoolean(context.getString(R.string.preference_enable_service), false);
+
+            if (useForegroundService){
+                context.startService(new Intent(context, AN2LinuxService.class));
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/shared_prefs_keys.xml
+++ b/app/src/main/res/values/shared_prefs_keys.xml
@@ -8,6 +8,7 @@
     <string name="certificate">certificate</string>
     <string name="version_code_seen">version_code_seen</string>
     <string name="preference_enable_an2linux">preference_enable_an2linux</string>
+    <string name="preference_enable_service">preference_enable_service</string>
     <string name="preference_enable_disable_all_applications">preference_enable_disable_all_applications</string>
     <string name="preference_include_notification_title">preference_include_notification_title</string>
     <string name="preference_force_title">preference_force_title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,4 +117,5 @@
     <string name="notif_settings_custom_no_enabled_summary">Tap here to enter the \'Enabled applications\' settings</string>
     <string name="notif_settings_min_notification_priority_title">Minimum notification priority</string>
     <string name="main_changelog">Changelog</string>
+    <string name="utils_an2linux_service">AN2Linux foreground service</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,14 @@
     <string name="main_settings_category_title">Settings</string>
     <string name="main_settings_category_about">About</string>
     <string name="main_enable_an2linux">Enable AN2Linux</string>
+    <string name="main_enable_service">Enable foreground service</string>
+    <string name="main_enable_service_notification_channel_name">AN2Linux foreground service</string>
+    <string name="main_enable_service_information_notification_channel_name">AN2Linux information channel</string>
+    <string name="main_enable_service_information_notification_title">How to hide AN2Linux Notification</string>
+    <string name="main_enable_service_information_notification_text">To hide the notification dot of the service
+        notification, open the notification settings of this app, click on the service channel name and set the
+        importance to low.
+    </string>
     <string name="main_enabled_apps_summary">Send notifications from these apps only</string>
     <string name="main_server_configuration_summary">Add a server to send notifications to</string>
     <string name="main_display_test_notification">Display test notification</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="main_source_code_server">Source code server</string>
     <string name="main_source_code_server_link">https://github.com/rootkiwi/an2linuxserver</string>
     <string name="main_dialog_ask_notification_access">AN2Linux requires access to your notifications. When the notification settings will open, enable AN2Linux then hit the back button.</string>
+    <string name="main_dialog_ask_coarse_location_access">AN2Linux requires access to your coarse location to obtain the WiFi SSID. When the permission settings will open, grant the location permission.</string>
     <string name="enabled_apps_enable_disable_all">Enable/disable all</string>
     <string name="empty_view_text_server_configuration">There are three different kind of "servers": WiFi, Mobile and Bluetooth.\n\nWhat that means is simply that AN2Linux will only try to send notifications to a server if you are connected to that type.\n\nFor example if you are connected to WiFi it will only try to send to all enabled WiFi servers and not to any mobile servers.\n\nBluetooth is kinda special, here "connected" means that bluetooth is turned on.</string>
     <string name="connection_type_wifi">WiFi</string>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -9,6 +9,12 @@
             android:title="@string/main_enable_an2linux"
             android:widgetLayout="@layout/appcompat_switch_layout" />
 
+        <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="@string/preference_enable_service"
+                    android:title="@string/main_enable_service"
+                    android:widgetLayout="@layout/appcompat_switch_layout" />
+
         <Preference
             android:summary="@string/main_enabled_apps_summary"
             android:title="@string/activity_label_enabled_applications">

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -11,6 +11,7 @@
 
         <CheckBoxPreference
                     android:defaultValue="false"
+                    android:dependency="@string/preference_enable_an2linux"
                     android:key="@string/preference_enable_service"
                     android:title="@string/main_enable_service"
                     android:widgetLayout="@layout/appcompat_switch_layout" />

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Apr 01 00:44:55 CEST 2017
+#Sat May 19 19:20:31 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This adds an option to run a service in the foreground to keep the app from being destroyed. After updating to Oreo the app missed a lot of notifications - before Oreo I didn't had any problems as the app was pretty responsive / wasn't destroyed.  The service fixes this problem as it keeps the app running.
Additionally I increased the target sdk to 28 as this allows the user to hide the notification dot from the system bar (manually).

I'm not an android developer so there might be some things that can be solved easier - feedback is welcome.
I tested this patch set on CarbonROM / Android 8.1.0 and can't vouch how other versions will behave.