### PR TITLE
WIP: Add appname to notification data

### DIFF
--- a/app/src/main/java/kiwi/root/an2linuxclient/data/Notification.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/data/Notification.java
@@ -19,6 +19,7 @@ import android.service.notification.StatusBarNotification;
 
 public class Notification {
 
+    private String appName;
     private String title;
     private String message;
     private Bitmap icon;
@@ -34,6 +35,11 @@ public class Notification {
 
         PackageManager pm =  c.getPackageManager();
         String packageName = sbn.getPackageName();
+        try {
+            appName = (String) pm.getApplicationLabel(pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA));
+        } catch (PackageManager.NameNotFoundException e) {
+            appName = packageName;
+        }
 
         if (ns.includeTitle()){
             String contentTitle = "";
@@ -42,15 +48,7 @@ public class Notification {
                 contentTitle = temp.toString();
             }
 
-            String appName;
-            try {
-                appName = (String) pm.getApplicationLabel(pm.getApplicationInfo(packageName, PackageManager.GET_META_DATA));
-            } catch (PackageManager.NameNotFoundException e) {
-                appName = packageName;
-            }
-
             title = "";
-
             if (ns.forceTitle()){
                 title = appName;
             } else {
@@ -117,6 +115,10 @@ public class Notification {
         drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
         drawable.draw(canvas);
         return bitmap;
+    }
+
+    public String getAppName() {
+        return this.appName;
     }
 
     public String getTitle() {

--- a/app/src/main/java/kiwi/root/an2linuxclient/network/TcpNotificationConnection.java
+++ b/app/src/main/java/kiwi/root/an2linuxclient/network/TcpNotificationConnection.java
@@ -75,6 +75,11 @@ class TcpNotificationConnection extends NotificationConnection {
 
             out.write(ns.getNotificationFlags());
 
+            String appName = n.getAppName();
+            byte[] appName_payload = (appName).getBytes();
+            out.write(ConnectionHelper.intToByteArray(appName_payload.length));
+            out.write(appName_payload);
+
             if (ns.includeTitle() || ns.includeMessage()){
                 String title = "";
                 if (ns.includeTitle()){


### PR DESCRIPTION
An attempt to add appName as mentioned [here](https://github.com/rootkiwi/an2linuxserver/pull/38).
It's not working 100% at the moment since I've probably messed up the data flow with my injection, hence the WIP. Probably an easy fix for @rootkiwi.

I was thinking to have appName sent at all times but given the way the data is sent it seems like this would break compatibilty with older versions of the server, so I guess it's better to be an option?