### PR TITLE
Disable error on lint

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "kiwi.root.an2linuxclient"
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 10
-        versionName "0.8.0"
+        versionCode 11
+        versionName "0.8.1"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,10 @@ android {
             versionNameSuffix '-DEBUG'
         }
     }
+    lintOptions {
+        // disable errors on lint
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/app/src/main/res/values/changelog.xml
+++ b/app/src/main/res/values/changelog.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="changelog">
+        &lt;b&gt;0.8.1 (Feb 26, 2019)&lt;/b&gt;&lt;br&gt;
+        - Fix build bug which is stopping F-Droid, now disable error on lint. Thank you edaubert!&lt;br&gt;&lt;br&gt;
+        - German translation by Luensche, thank you!&lt;br&gt;&lt;br&gt;
         &lt;b&gt;0.8.0 (May 26, 2018)&lt;/b&gt;&lt;br&gt;
         - From Android 8.1 COARSE_LOCATION permission is needed to access WiFi SSID! Also it seems
         that location services needs to be turned on as well, otherwise the SSID reported will


### PR DESCRIPTION
Small fix about #24 

@rootkiwi I did not update the version.

Do you want me to do it as I start from the v0.8.0 version.
If we create the 0.8.1, this can be merge and pushed on f-droid.

I propose this as I don't know what is the impact of the newt changes in master even if the commit message is about translation.

If you prefer to apply it on master, I can do the changes too.